### PR TITLE
[feat] Documentação da OpenAPI em todas as entidades externalizadas #37

### DIFF
--- a/src/main/java/br/com/nivlabs/gp/models/dto/ResponsibleInfoDTO.java
+++ b/src/main/java/br/com/nivlabs/gp/models/dto/ResponsibleInfoDTO.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -22,8 +23,13 @@ public class ResponsibleInfoDTO extends PersonInfoDTO {
 
     private static final long serialVersionUID = 3558512431533807447L;
 
+    @ApiModelProperty("Registro profissional do responsável (Se houver)")
     private ProfessionalIdentityDTO professionalIdentity;
+
+    @ApiModelProperty("Data / Hora de criação")
     private LocalDateTime createdAt;
+
+    @ApiModelProperty("Especializaçõs do responsável (Se houver)")
     private List<SpecialityDTO> specializations = new ArrayList<>();
 
 }

--- a/src/main/java/br/com/nivlabs/gp/models/dto/RoleDTO.java
+++ b/src/main/java/br/com/nivlabs/gp/models/dto/RoleDTO.java
@@ -1,6 +1,7 @@
 package br.com.nivlabs.gp.models.dto;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -21,9 +22,12 @@ public class RoleDTO extends DataTransferObjectBase {
 
     private static final long serialVersionUID = -4723369199443894800L;
 
+    @ApiModelProperty("Identificador único do papel do usuário")
     private Long id;
 
+    @ApiModelProperty("Nome do papel do usuário")
     private String name;
 
+    @ApiModelProperty("Descrição do papel do usuáiro")
     private String description;
 }

--- a/src/main/java/br/com/nivlabs/gp/models/dto/SectorDTO.java
+++ b/src/main/java/br/com/nivlabs/gp/models/dto/SectorDTO.java
@@ -1,6 +1,7 @@
 package br.com.nivlabs.gp.models.dto;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,10 +21,12 @@ import lombok.NoArgsConstructor;
 @ApiModel("Setor")
 public class SectorDTO extends DataTransferObjectBase {
 
-	private static final long serialVersionUID = -8018406138528606923L;
+    private static final long serialVersionUID = -8018406138528606923L;
 
-	private Long id;
+    @ApiModelProperty("Identificador único do setor")
+    private Long id;
 
-	private String description;
+    @ApiModelProperty("Descrição do setor")
+    private String description;
 
 }

--- a/src/main/java/br/com/nivlabs/gp/models/dto/SectorInfoDTO.java
+++ b/src/main/java/br/com/nivlabs/gp/models/dto/SectorInfoDTO.java
@@ -8,6 +8,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -27,15 +28,19 @@ import lombok.NoArgsConstructor;
 @ApiModel("Informações do Setor")
 public class SectorInfoDTO extends DataTransferObjectBase {
 
-	private static final long serialVersionUID = -8018406138528606923L;
+    private static final long serialVersionUID = -8018406138528606923L;
 
-	private Long id;
+    @ApiModelProperty("Identificador único do setor")
+    private Long id;
 
-	private String description;
+    @ApiModelProperty("Descrição do setor")
+    private String description;
 
-	private List<AccomodationDTO> listOfRoomsOrBeds = new ArrayList<>();
+    @ApiModelProperty("Lista de salas e leitos do setor (Acomodações)")
+    private List<AccomodationDTO> listOfRoomsOrBeds = new ArrayList<>();
 
-	@DateTimeFormat(iso = ISO.DATE)
-	private LocalDateTime createdAt;
+    @ApiModelProperty("Data / Hora de criação do setor")
+    @DateTimeFormat(iso = ISO.DATE)
+    private LocalDateTime createdAt;
 
 }

--- a/src/main/java/br/com/nivlabs/gp/models/dto/ServerStatusDTO.java
+++ b/src/main/java/br/com/nivlabs/gp/models/dto/ServerStatusDTO.java
@@ -3,6 +3,7 @@ package br.com.nivlabs.gp.models.dto;
 import java.util.Date;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -18,8 +19,15 @@ import lombok.EqualsAndHashCode;
 public class ServerStatusDTO extends DataTransferObjectBase {
     private static final long serialVersionUID = -8293328535500084535L;
 
+    @ApiModelProperty("Data / Hora atual do servidor")
     private Date currentDate = new Date();
+
+    @ApiModelProperty("Nonme da aplicação")
     private String applicationName = "API Gestão de Prontuário";
+
+    @ApiModelProperty("Veersão da aplicação")
     private String version = "DEV";
+
+    @ApiModelProperty("Status do servidor")
     private String status = "Ligado";
 }


### PR DESCRIPTION
# Descrição

Adicionei todas as descrições de propriedades faltantes nas classes de externalização da API.

## Tipo de alteração

Não marque as opções que não são relevantes.

- [ ] Correção de bug (alteração ininterrupta que corrige um problema)
- [x] Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [ ] Quebra de alteração (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [ ] Esta alteração requer uma atualização da documentação

# Como isso foi testado?

Para realizar o teste, levantei a aplicação e observei se as descrições foram adicionadas ao Swagger, como mostra na figura abaixo:
![image](https://user-images.githubusercontent.com/7918549/87875292-afd5cd00-c9a6-11ea-9b05-e32636037f4e.png)

Implementação de exemplo abaixo:
![image](https://user-images.githubusercontent.com/7918549/87875300-bd8b5280-c9a6-11ea-847c-a7aea0bd5864.png)

# Lista de controle:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Eu realizei uma auto-revisão do meu próprio código
- [x] Comentei meu código, principalmente em áreas difíceis de entender
- [x] Fiz as alterações correspondentes na documentação
- [x] Minhas alterações não geram novos avisos
- [x] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [x] Os testes de unidade novos e existentes passam localmente com minhas alterações
